### PR TITLE
Update plugin.directresize2.php

### DIFF
--- a/_build2/resolvers/core/components/directresize2/elements/plugins/plugin.directresize2.php
+++ b/_build2/resolvers/core/components/directresize2/elements/plugins/plugin.directresize2.php
@@ -191,6 +191,7 @@ if (!function_exists('css_parse')) {
 	function css_parse($styles){
 		// parse css and get all the key:value pair styles
 		$css_array = array(); // master array to hold all values
+		$styles = str_replace(" ","",$styles);
 		if (isset($styles) and $styles = explode(';', strtolower($styles)) and !empty($styles)){
 			foreach ($styles as $style) {
 				$value = explode(':', $style);


### PR DESCRIPTION
Редактор CKEditor в стилях проставляет пробелы между свойствами, из-за чего некорректно определяется ширина и высота в стилях.
